### PR TITLE
Implement CAMOFOX_DEFAULT_PRESET for session configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -443,6 +443,7 @@ Source of truth: `src/utils/config.ts`, `src/services/session.ts`, `src/services
 | `CAMOFOX_MAX_SESSIONS` | `50` | Max live sessions |
 | `CAMOFOX_MAX_TABS` | `10` | Max tabs per session |
 | `CAMOFOX_PRESETS_FILE` | unset | Custom presets JSON file |
+| `CAMOFOX_DEFAULT_PRESET` | unset | Optional default preset name used for session locale/timezone/geolocation when no proxy is configured and no overrides are supplied; falls back to the first built-in preset if unset/invalid |
 | `PROXY_HOST` | empty | Proxy host |
 | `PROXY_PORT` | empty | Proxy port |
 | `PROXY_USERNAME` | empty | Proxy username |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ CamoFox is a TypeScript browser automation server + CLI over the Camoufox anti-d
 ## Key Context
 - Default server URL: `http://localhost:9377`
 - Default port envs: `CAMOFOX_PORT` / `PORT` (typically 9377)
+ - Default preset env var: `CAMOFOX_DEFAULT_PRESET` (optional) — when set and no proxy is configured, this preset's locale/timezone/geolocation are used for new sessions if the caller provides no overrides.
 - Core identity fields: `userId`, `tabId`, `sessionKey` (or legacy `listItemId`)
 - Refs come from snapshot as `eN`-style element references
 

--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Custom presets: set `CAMOFOX_PRESETS_FILE=/path/to/presets.json` (JSON object; k
 | `CAMOFOX_CLI_USER` | `cli-default` | Default CLI user id |
 | `CAMOFOX_IDLE_TIMEOUT_MS` | `1800000` | CLI server idle timeout |
 | `CAMOFOX_PRESETS_FILE` | (unset) | Optional JSON file defining/overriding geo presets |
+| `CAMOFOX_DEFAULT_PRESET` | (unset) | Optional default preset name used for session locale/timezone/geolocation when no proxy is configured and no overrides are supplied; falls back to the first built-in preset if unset/invalid |
 | `CAMOFOX_SESSION_TIMEOUT` | `1800000` | Session idle timeout in ms (min `60000`) |
 | `CAMOFOX_MAX_SESSIONS` | `50` | Maximum concurrent sessions |
 | `CAMOFOX_MAX_TABS` | `10` | Maximum tabs per session |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "camofox-browser",
-  "version": "2.0.5",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camofox-browser",
-      "version": "2.0.5",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "camoufox-js": "^0.8.5",
-        "commander": "^14.0.0",
         "express": "^4.18.2",
         "playwright-core": "^1.58.0"
       },
       "bin": {
-        "camofox": "bin/camofox.js",
         "camofox-browser": "bin/camofox-browser.js"
       },
       "devDependencies": {
@@ -28,10 +26,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20"
-      },
-      "optionalDependencies": {
-        "argon2": "^0.41.1"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1447,16 +1442,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@phc/format": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
-      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1776,22 +1761,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/argon2": {
-      "version": "0.41.1",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.41.1.tgz",
-      "integrity": "sha512-dqCW8kJXke8Ik+McUcMDltrbuAWETPyU6iq+4AhxqKphWi7pChB/Zgd/Tp/o8xRLbg8ksMj46F/vph9wnxpTzQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@phc/format": "^1.0.0",
-        "node-addon-api": "^8.1.0",
-        "node-gyp-build": "^4.8.1"
-      },
-      "engines": {
-        "node": ">=16.17.0"
       }
     },
     "node_modules/argparse": {
@@ -4777,28 +4746,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
-      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/src/services/session.ts
+++ b/src/services/session.ts
@@ -4,6 +4,7 @@ import type { ContextOverrides, SessionData, TabState } from '../types';
 import { log } from '../middleware/logging';
 import { clearTabLock, clearAllTabLocks } from './tab';
 import { loadConfig } from '../utils/config';
+import { BUILT_IN_PRESETS, resolvePreset } from '../utils/presets';
 import { contextPool } from './context-pool';
 import { cleanupUserDownloads } from './download';
 import { decrementActiveOps, incrementActiveOps } from './health';
@@ -244,10 +245,32 @@ export async function getSession(userId: unknown, contextOverrides?: ContextOver
 
 	// With proxy+geoip, camoufox auto-configures locale/timezone/geo from proxy IP.
 	// If caller explicitly supplies overrides, apply them even when proxy is active.
+	// Determine default preset options: configured default or fallback to first built-in
+	let defaultPresetOptions: Record<string, unknown> | null = null;
+	const configuredDefault = CONFIG.defaultPreset && CONFIG.defaultPreset.trim() ? CONFIG.defaultPreset.trim() : '';
+	if (configuredDefault) {
+		const presetResolved = resolvePreset(configuredDefault);
+		if (presetResolved) {
+			defaultPresetOptions = presetResolved as Record<string, unknown>;
+		} else {
+			log('warn', 'configured default preset not found, falling back to built-in first preset', { preset: configuredDefault });
+		}
+	}
+	if (!defaultPresetOptions) {
+		const builtinKeys = Object.keys(BUILT_IN_PRESETS);
+		if (builtinKeys.length) {
+			const first = builtinKeys[0];
+			const presetResolved = resolvePreset(first);
+			if (presetResolved) defaultPresetOptions = presetResolved as Record<string, unknown>;
+		}
+	}
+
+	// With proxy+geoip, camoufox auto-configures locale/timezone/geo from proxy IP.
+	// If caller explicitly supplies overrides, apply them even when proxy is active.
 	if (!CONFIG.proxy.host || hasOverrides) {
-		contextOptions.locale = resolved.locale || 'en-US';
-		contextOptions.timezoneId = resolved.timezoneId || 'America/Los_Angeles';
-		contextOptions.geolocation = resolved.geolocation || { latitude: 37.7749, longitude: -122.4194 };
+		contextOptions.locale = resolved.locale || (defaultPresetOptions?.locale as string) || 'en-US';
+		contextOptions.timezoneId = resolved.timezoneId || (defaultPresetOptions?.timezoneId as string) || 'America/Los_Angeles';
+		contextOptions.geolocation = resolved.geolocation || (defaultPresetOptions?.geolocation as { latitude: number; longitude: number }) || { latitude: 37.7749, longitude: -122.4194 };
 	}
 
 	if (!session) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -46,6 +46,7 @@ export interface ServerEnv {
   PROXY_PORT?: string;
   PROXY_USERNAME?: string;
   PROXY_PASSWORD?: string;
+  CAMOFOX_DEFAULT_PRESET?: string;
 }
 
 export interface AppConfig {
@@ -77,6 +78,7 @@ export interface AppConfig {
   evalExtendedRateLimitWindowMs: number;
   proxy: ProxyConfig;
   serverEnv: ServerEnv;
+  defaultPreset: string;
 }
 
 export interface ConfigEnv extends NodeJS.ProcessEnv {
@@ -111,6 +113,7 @@ export interface ConfigEnv extends NodeJS.ProcessEnv {
   PROXY_PORT?: string;
   PROXY_USERNAME?: string;
   PROXY_PASSWORD?: string;
+  CAMOFOX_DEFAULT_PRESET?: string;
   PATH?: string;
   HOME?: string;
 }
@@ -175,6 +178,8 @@ export function loadConfig(env: ConfigEnv = process.env): AppConfig {
   const evalExtendedRateLimitMax = parsePositiveIntOrDefault(env.CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_MAX, 20);
   const evalExtendedRateLimitWindowMs = parsePositiveIntOrDefault(env.CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_WINDOW_MS, 60000);
 
+  const defaultPreset = env.CAMOFOX_DEFAULT_PRESET || '';
+
   const downloadTtlMs = parsePositiveIntOrDefault(env.CAMOFOX_DOWNLOAD_TTL_MS, 86_400_000);
   const maxDownloadSizeMb = parsePositiveIntOrDefault(env.CAMOFOX_MAX_DOWNLOAD_SIZE_MB, 100);
   const maxBatchConcurrency = parsePositiveIntOrDefault(env.CAMOFOX_MAX_BATCH_CONCURRENCY, 5);
@@ -208,6 +213,7 @@ export function loadConfig(env: ConfigEnv = process.env): AppConfig {
     headless,
     evalExtendedRateLimitMax,
     evalExtendedRateLimitWindowMs,
+    defaultPreset,
     proxy: {
       host: env.PROXY_HOST || '',
       port: env.PROXY_PORT || '',
@@ -241,6 +247,7 @@ export function loadConfig(env: ConfigEnv = process.env): AppConfig {
       CAMOFOX_HEADLESS: env.CAMOFOX_HEADLESS,
       CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_MAX: env.CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_MAX,
       CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_WINDOW_MS: env.CAMOFOX_EVAL_EXTENDED_RATE_LIMIT_WINDOW_MS,
+      CAMOFOX_DEFAULT_PRESET: env.CAMOFOX_DEFAULT_PRESET,
       PROXY_HOST: env.PROXY_HOST,
       PROXY_PORT: env.PROXY_PORT,
       PROXY_USERNAME: env.PROXY_USERNAME,


### PR DESCRIPTION
This pull request adds support for specifying a default preset for session locale, timezone, and geolocation using a new environment variable, `CAMOFOX_DEFAULT_PRESET`. When no proxy is configured and no overrides are supplied, this preset is used for new sessions. If the configured preset is invalid or unset, the system falls back to the first built-in preset. The change is documented across user-facing documentation and implemented in the configuration and session logic.

**Environment variable and configuration support:**

* Added `CAMOFOX_DEFAULT_PRESET` to the environment variable schema in `src/utils/config.ts`, updated `ServerEnv`, `AppConfig`, and `ConfigEnv` interfaces, and ensured it is loaded and exposed in the app configuration. [[1]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR49) [[2]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR81) [[3]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR116) [[4]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR181-R182) [[5]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR216) [[6]](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bR250)

**Session creation logic:**

* Updated `getSession` in `src/services/session.ts` to use the configured default preset (or the first built-in preset as a fallback) for locale, timezone, and geolocation when no proxy is active and no overrides are provided. Added fallback logging if the configured preset is invalid. [[1]](diffhunk://#diff-7943c985c5c50ae9b82b222acd2eba0141a32e7cb8bc53ca4b5a6ef24d7d8147R7) [[2]](diffhunk://#diff-7943c985c5c50ae9b82b222acd2eba0141a32e7cb8bc53ca4b5a6ef24d7d8147R246-R273)

**Documentation updates:**

* Documented the new `CAMOFOX_DEFAULT_PRESET` environment variable and its behavior in `README.md`, `AGENTS.md`, and `CLAUDE.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R623) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R446) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R9)