### PR TITLE
Document TweetClaw workflows and fix plugin URL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Normalized trailing slashes in the OpenClaw plugin server URL so health checks and tool requests do not produce double-slash paths.
+
+### Docs
+- Documented the boundary between browser interaction and structured X workflows.
+
 ## [2.4.7] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [API Reference](#api-reference)
 - [Structured Extract](#structured-extract)
 - [Search Macros](#search-macros)
+- [Structured X Workflows](#structured-x-workflows)
 - [Geo Presets](#geo-presets)
 - [Environment Variables](#environment-variables)
 - [Deployment](#deployment)
@@ -713,6 +714,29 @@ Use macros via `POST /tabs/:tabId/navigate` with `{ "macro": "@google_search", "
 | `@tiktok_search` | TikTok |
 | `@twitch_search` | Twitch |
 
+## Structured X Handoff
+
+The `@twitter_search` macro opens X web search in a CamoFox tab. Use CamoFox for
+interactive or visual browser work. Use
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) when a workflow needs
+structured X data or an approval-gated account action.
+
+Keep each plugin focused:
+
+| Need | Use |
+|------|-----|
+| Open a page, inspect visual state, or interact with a site | CamoFox |
+| Search tweets, read profiles, or inspect replies as structured data | TweetClaw |
+| Run an approval-gated X account action or monitor | TweetClaw |
+| Verify a linked site from structured X results | TweetClaw, then CamoFox |
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Pass returned URLs to CamoFox only when browser verification is necessary. Do
+not send API keys through browser forms, page scripts, screenshots, or logs.
+
 ## Geo Presets
 
 Built-in presets (also exposed via `GET /presets`):
@@ -1002,6 +1026,7 @@ fly deploy
 | [CamoFox MCP](https://github.com/redf0x1/camofox-mcp) | MCP (Model Context Protocol) server for Claude, Cursor, VS Code |
 | [OpenClaw](https://openclaw.ai) | Open-source AI agent framework (compat endpoints included) |
 | [Camoufox](https://github.com/daijro/camoufox) | Anti-detection Firefox browser engine |
+| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | Structured X workflows for OpenClaw; pair with CamoFox for browser verification |
 
 ## Project Structure
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -10,7 +10,7 @@ import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
 
-import { loadConfig } from "./dist/src/utils/config.js";
+import { loadConfig, normalizeServerBaseUrl } from "./dist/src/utils/config.js";
 import { launchServer } from "./dist/src/utils/launcher.js";
 import { readCookieFile } from "./dist/src/utils/cookies.js";
 
@@ -209,7 +209,7 @@ function toToolResult(data: unknown): ToolResult {
 export default function register(api: PluginApi) {
   const cfg = api.pluginConfig ?? (api.config as unknown as PluginConfig);
   const port = cfg.port || 9377;
-  const baseUrl = cfg.url || `http://localhost:${port}`;
+  const baseUrl = normalizeServerBaseUrl(cfg.url || `http://localhost:${port}`);
   const autoStart = cfg.autoStart !== false; // default true
   const pluginDir = getPluginDir();
   const fallbackUserId = `camofox-${randomUUID()}`;

--- a/skills/camofox-browser/SKILL.md
+++ b/skills/camofox-browser/SKILL.md
@@ -35,6 +35,18 @@ Use REST API when:
 - You need strict request/response control with explicit `userId` and `tabId`.
 - You need OpenClaw-compatible route shape (`/tabs/open`, `/act`, `/snapshot`).
 
+### Structured X workflow boundary
+
+Use CamoFox when an X workflow requires interactive browser state or visual
+verification. Use the
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) OpenClaw plugin for
+structured tweet search, profile and reply reads, monitors, and approved X
+account actions. Pass a linked site from TweetClaw to CamoFox only when browser
+inspection is necessary.
+
+Do not send API credentials through CamoFox forms, page scripts, screenshots,
+or logs.
+
 ## 1) Core Workflow (CLI + API dual interface)
 
 Follow this loop for reliable automation:

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -275,6 +275,14 @@ export function isLoopbackHost(host: string): boolean {
   return false;
 }
 
+export function normalizeServerBaseUrl(value: string): string {
+  const normalized = value.trim().replace(/\/+$/u, '');
+  if (!normalized) {
+    throw new Error('CamoFox server URL must be a non-empty string');
+  }
+  return normalized;
+}
+
 function hasConfiguredProxy(proxy: Pick<ProxyConfig, 'host' | 'port'>): boolean {
   return Boolean(proxy.host && proxy.port);
 }

--- a/tests/unit/plugin-base-url.test.js
+++ b/tests/unit/plugin-base-url.test.js
@@ -1,0 +1,24 @@
+const { normalizeServerBaseUrl } = require('../../dist/src/utils/config');
+
+describe('OpenClaw plugin server URL normalization', () => {
+  test('keeps a URL without a trailing slash unchanged', () => {
+    expect(normalizeServerBaseUrl('http://localhost:9377'))
+      .toBe('http://localhost:9377');
+  });
+
+  test('removes trailing slashes before endpoint paths are appended', () => {
+    const baseUrl = normalizeServerBaseUrl('http://localhost:9377///');
+
+    expect(`${baseUrl}/health`).toBe('http://localhost:9377/health');
+  });
+
+  test('preserves a configured path prefix', () => {
+    expect(normalizeServerBaseUrl('https://browser.example/camofox/'))
+      .toBe('https://browser.example/camofox');
+  });
+
+  test('rejects a blank configured URL', () => {
+    expect(() => normalizeServerBaseUrl('   '))
+      .toThrow('CamoFox server URL must be a non-empty string');
+  });
+});


### PR DESCRIPTION
## Summary

- Document when to use CamoFox and TweetClaw together.
- Add official installation, configuration, allowlist, and verification steps.
- Link the official OpenClaw setup guide.
- Preserve CamoFox as the interactive browser layer.
- Keep structured X reads and approved actions in TweetClaw.

## Independent Fix

Configured server URLs could end with `/`. The plugin then requested paths such as `//health`, which Express rejected.

This PR now normalizes the configured base URL before appending endpoint paths. It also rejects blank URLs and preserves path prefixes.

## Validation

- `npm run lint`
- `npm run build`
- Full Jest suite in 8 bounded shards: 499 passed, 18 opt-in tests skipped
- Targeted plugin and macro tests: 23 passed
- `npm run verify:package`
- Official documentation links return HTTP 200
- `git diff --check`

The full suite used Node 24. Node 26 is outside one native dependency's supported V8 range.
