### PR TITLE
fix: validate userId on evaluate and delete-tab endpoints

### DIFF
--- a/src/routes/core.ts
+++ b/src/routes/core.ts
@@ -932,6 +932,7 @@ router.post(
 			}
 
 			const { userId, expression, timeout } = req.body;
+			if (!userId) return res.status(400).json({ error: 'userId is required' });
 			if (!expression || typeof expression !== 'string') {
 				return res.status(400).json({ error: 'expression is required and must be a string' });
 			}
@@ -1267,6 +1268,7 @@ router.delete('/tabs/:tabId', async (req: Request<{ tabId: string }, unknown, { 
 		}
 
 		const { userId } = req.body;
+		if (!userId) return res.status(400).json({ error: 'userId is required' });
 		const found = findTabById(req.params.tabId, userId);
 		if (found) {
 			await safePageClose(found.tabState.page);

--- a/tests/unit/userid-validation.test.js
+++ b/tests/unit/userid-validation.test.js
@@ -1,0 +1,72 @@
+// Unit test: verify that evaluate and delete route handlers validate userId
+// Before the fix: evaluate returned 404 "Tab not found" (confusing),
+// delete returned { ok: true } (silent no-op). After fix: both return 400.
+
+describe('userId validation regression (core.ts routes)', () => {
+  // Read the source file and verify the guards exist
+  const fs = require('fs');
+  const path = require('path');
+  const sourcePath = path.join(__dirname, '../../src/routes/core.ts');
+  const source = fs.readFileSync(sourcePath, 'utf-8');
+
+  test('evaluate handler validates userId before findTabById', () => {
+    // Find the evaluate handler block
+    const evalMatch = source.match(/router\.post\(\s*['"]\/tabs\/:tabId\/evaluate['"]/);
+    expect(evalMatch).not.toBeNull();
+
+    // Extract the handler body (up to the next router.* call)
+    const evalStart = source.indexOf(evalMatch[0]);
+    const nextRoute = source.indexOf('router.', evalStart + 1);
+    const handlerBlock = source.substring(evalStart, nextRoute > 0 ? nextRoute : evalStart + 2000);
+
+    // Should contain the userId guard
+    expect(handlerBlock).toContain("if (!userId)");
+    expect(handlerBlock).toContain("'userId is required'");
+  });
+
+  test('delete handler validates userId before findTabById', () => {
+    const deleteMatch = source.match(/router\.delete\(\s*['"]\/tabs\/:tabId['"]/);
+    expect(deleteMatch).not.toBeNull();
+
+    const deleteStart = source.indexOf(deleteMatch[0]);
+    const nextRoute = source.indexOf('router.', deleteStart + 1);
+    const handlerBlock = source.substring(deleteStart, nextRoute > 0 ? nextRoute : deleteStart + 1000);
+
+    // Should contain the userId guard
+    expect(handlerBlock).toContain("if (!userId)");
+    expect(handlerBlock).toContain("'userId is required'");
+  });
+
+  test('delete handler does NOT silently return ok:true when userId is missing', () => {
+    // The old code path: userId missing → findTabById returns null → if(found) skipped → res.json({ok:true})
+    // The new code path: userId missing → 400 error before findTabById is called
+    const deleteMatch = source.match(/router\.delete\(\s*['"]\/tabs\/:tabId['"]/);
+    const deleteStart = source.indexOf(deleteMatch[0]);
+    const nextRoute = source.indexOf('router.', deleteStart + 1);
+    const handlerBlock = source.substring(deleteStart, nextRoute > 0 ? nextRoute : deleteStart + 1000);
+
+    // The guard should come BEFORE findTabById
+    const guardPos = handlerBlock.indexOf("if (!userId)");
+    const findTabPos = handlerBlock.indexOf("findTabById");
+    expect(guardPos).toBeGreaterThan(-1);
+    expect(findTabPos).toBeGreaterThan(-1);
+    expect(guardPos).toBeLessThan(findTabPos);
+  });
+
+  test('evaluate handler guard is consistent with evaluate-extended handler', () => {
+    // evaluate-extended already had the guard — evaluate should now match
+    const extMatch = source.match(/router\.post\(\s*['"]\/tabs\/:tabId\/evaluate-extended['"]/);
+    const extStart = source.indexOf(extMatch[0]);
+    const extNext = source.indexOf('router.', extStart + 1);
+    const extBlock = source.substring(extStart, extNext > 0 ? extNext : extStart + 2000);
+
+    const evalMatch = source.match(/router\.post\(\s*['"]\/tabs\/:tabId\/evaluate['"]\s*,/);
+    const evalStart = source.indexOf(evalMatch[0]);
+    const evalNext = source.indexOf('router.', evalStart + 1);
+    const evalBlock = source.substring(evalStart, evalNext > 0 ? evalNext : evalStart + 2000);
+
+    // Both should have userId validation
+    expect(extBlock).toContain("userId");
+    expect(evalBlock).toContain("if (!userId)");
+  });
+});


### PR DESCRIPTION
## Bug Description

The `POST /tabs/:tabId/evaluate` and `DELETE /tabs/:tabId` handlers do not validate that `userId` is present in the request body before calling `findTabById`. This causes two confusing failure modes when `userId` is missing (e.g., when a client passes it as a query parameter instead of in the JSON body):

1. **`POST /tabs/:tabId/evaluate`** returns `404 { "error": "Tab not found" }` — the tab exists, but `findTabById` returns `null` because `userId` is `undefined`. The real problem (missing `userId` in body) is masked as a missing tab.

2. **`DELETE /tabs/:tabId`** returns `200 { "ok": true }` **without actually closing the tab** — the handler skips the entire `if (found) { ... }` block silently, then falls through to `res.json({ ok: true })`. The caller believes the tab was closed, but it was not. Stale tabs accumulate until `"Maximum tabs per session reached"`.

## Root Cause

Both handlers read `userId` from `req.body` but do not check for its presence before using it. Other handlers in the same file already validate `userId`:

- `POST /tabs/:tabId/navigate` — `if (!userId) return res.status(400).json({ error: 'userId required' });`
- `POST /tabs/:tabId/click` — same guard
- `POST /tabs/:tabId/evaluate-extended` — `if (!userId || typeof userId !== 'string') return res.status(400).json({ ... });`

The `evaluate` and `delete` handlers are missing this guard.

## Fix

Added `if (!userId) return res.status(400).json({ error: 'userId is required' });` to both handlers, matching the existing pattern in `navigate` and `click`.

- `src/routes/core.ts` — 2 lines added (one guard per handler)
- `tests/unit/userid-validation.test.js` — 4 regression tests verifying the guards exist and come before `findTabById`

## How to Verify

1. Start the server: `npx camofox-browser serve --port 9377`
2. Create a tab: `curl -X POST http://localhost:9377/tabs -H 'content-type: application/json' -d '{"url":"https://example.com","userId":"test"}'`
3. **Before fix — evaluate without userId in body:**
   ```
   curl -X POST http://localhost:9377/tabs/<tabId>/evaluate -H 'content-type: application/json' -d '{"expression":"document.title"}'
   → 404 {"error":"Tab not found"}  (confusing — tab exists)
   ```
4. **After fix:**
   ```
   curl -X POST http://localhost:9377/tabs/<tabId>/evaluate -H 'content-type: application/json' -d '{"expression":"document.title"}'
   → 400 {"error":"userId is required"}  (clear error)
   ```
5. Same pattern for DELETE — before fix returns `{"ok":true}` silently, after fix returns `400`.

## Test Plan

- [x] Added regression test (`tests/unit/userid-validation.test.js`) verifying both handlers have the guard before `findTabById`
- [x] `npm run lint` passes (`tsc --noEmit`)
- [x] `npm test` passes (4/4 new tests)
- [x] Manual verification of the fix matches existing handler patterns

## Risk Assessment

**Low** — the fix adds a 400 error for a case that was already broken (just with a confusing error or silent no-op). No existing valid callers are affected: any client passing `userId` in the body (the documented API contract) will see no change. Clients that were passing `userId` as a query param were already broken — they just get a clearer error now.