### PR TITLE
fix: prevent late blocked navigation from escaping action tracking

### DIFF
--- a/src/routes/openclaw.ts
+++ b/src/routes/openclaw.ts
@@ -571,7 +571,7 @@ router.post('/act', async (req: Request<unknown, unknown, Record<string, unknown
 						} else {
 							await tabState.page.locator(String(selector)).selectOption(value);
 						}
-					});
+					}, { settlePostActionNavigation: true });
 					return { ok: true, targetId };
 				}
 

--- a/src/services/tab.ts
+++ b/src/services/tab.ts
@@ -632,6 +632,10 @@ function decrementInFlightGuardCheck(page: Page): void {
 	}
 }
 
+function getInFlightGuardCheckCount(page: Page): number {
+	return inFlightGuardChecks.get(page) || 0;
+}
+
 function incrementTrackedInFlightGuardCheck(page: Page, token: number): void {
 	const existing = trackedInFlightGuardChecks.get(page) || new Map<number, number>();
 	existing.set(token, (existing.get(token) || 0) + 1);
@@ -656,6 +660,14 @@ function getTrackedInFlightGuardCheckCount(page: Page, token: number): number {
 	return trackedInFlightGuardChecks.get(page)?.get(token) || 0;
 }
 
+async function yieldToPostActionNavigation(page: Page): Promise<void> {
+	if (typeof page.waitForTimeout === 'function') {
+		await page.waitForTimeout(0);
+		return;
+	}
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 export async function flushBlockedNavigationError(page: Page): Promise<void> {
 	if (typeof page.waitForTimeout === 'function') {
 		await page.waitForTimeout(POST_ACTION_NAVIGATION_SETTLE_MS);
@@ -663,7 +675,16 @@ export async function flushBlockedNavigationError(page: Page): Promise<void> {
 	throwBlockedNavigationErrorIfPresent(page);
 }
 
-export async function withBlockedNavigationTracking<T>(page: Page, action: () => Promise<T>): Promise<T> {
+export interface BlockedNavigationTrackingOptions {
+	/** Yield once after actions whose DOM event can enqueue navigation after the action promise resolves. */
+	settlePostActionNavigation?: boolean;
+}
+
+export async function withBlockedNavigationTracking<T>(
+	page: Page,
+	action: () => Promise<T>,
+	options: BlockedNavigationTrackingOptions = {},
+): Promise<T> {
 	if (CONFIG.allowPrivateNetworkTargets) {
 		return action();
 	}
@@ -720,6 +741,25 @@ export async function withBlockedNavigationTracking<T>(page: Page, action: () =>
 		throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
 		if (sawPendingWork) {
 			throwBlockedNavigationErrorIfPresent(page);
+		}
+		if (options.settlePostActionNavigation) {
+			// Some DOM actions (for example selectOption with a synchronous
+			// location.href handler) enqueue navigation after the action promise
+			// resolves without creating tracked timer work. Yield once while the
+			// action token is still active so the route guard can associate that
+			// request with this action before the in-flight drain below.
+			await yieldToPostActionNavigation(page);
+			let postActionPendingWork = true;
+			while (postActionPendingWork) {
+				throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
+				const pendingCount = await getTrackedPendingCount(page, actionToken);
+				const inFlightGuardCount = getTrackedInFlightGuardCheckCount(page, actionToken);
+				postActionPendingWork = pendingCount > 0 || inFlightGuardCount > 0 || getInFlightGuardCheckCount(page) > 0;
+				if (postActionPendingWork) {
+					await new Promise((resolve) => setTimeout(resolve, ACTION_TRACKER_POLL_MS));
+				}
+			}
+			throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
 		}
 		await finish();
 		return result;
@@ -1108,34 +1148,42 @@ async function ensureNavigationSafetyGuard(page: Pick<Page, 'context'>, options:
 		const requestPage = requestFrame && typeof requestFrame.page === 'function' ? requestFrame.page() : null;
 		const relatedPages = new Set<Page>();
 		let trackedToken: number | null = null;
-		if (requestPage) {
-			relatedPages.add(requestPage);
-			trackedToken = await getCurrentTrackedActionToken(requestPage);
-			const mappedOpener = popupOpenerPages.get(requestPage);
-			if (mappedOpener) {
-				relatedPages.add(mappedOpener);
-				if (trackedToken === null) {
-					trackedToken = await getCurrentTrackedActionToken(mappedOpener);
-				}
-			} else if (typeof requestPage.opener === 'function') {
-				const openerPage = await requestPage.opener().catch(() => null);
-				if (openerPage) {
-					relatedPages.add(openerPage);
+		const addRelatedPage = (page: Page): void => {
+			if (relatedPages.has(page)) return;
+			relatedPages.add(page);
+			// Count the route before resolving the action token. The token lookup
+			// itself is asynchronous and the action wrapper must not finish while
+			// a guard check is still being associated with its page.
+			incrementInFlightGuardCheck(page);
+		};
+
+		try {
+			if (requestPage) {
+				addRelatedPage(requestPage);
+				trackedToken = await getCurrentTrackedActionToken(requestPage);
+				const mappedOpener = popupOpenerPages.get(requestPage);
+				if (mappedOpener) {
+					addRelatedPage(mappedOpener);
 					if (trackedToken === null) {
-						trackedToken = await getCurrentTrackedActionToken(openerPage);
+						trackedToken = await getCurrentTrackedActionToken(mappedOpener);
+					}
+				} else if (typeof requestPage.opener === 'function') {
+					const openerPage = await requestPage.opener().catch(() => null);
+					if (openerPage) {
+						addRelatedPage(openerPage);
+						if (trackedToken === null) {
+							trackedToken = await getCurrentTrackedActionToken(openerPage);
+						}
 					}
 				}
 			}
-		}
 
-		for (const relatedPage of relatedPages) {
-			incrementInFlightGuardCheck(relatedPage);
 			if (trackedToken !== null) {
-				incrementTrackedInFlightGuardCheck(relatedPage, trackedToken);
+				for (const relatedPage of relatedPages) {
+					incrementTrackedInFlightGuardCheck(relatedPage, trackedToken);
+				}
 			}
-		}
 
-		try {
 			const requestError = await validateNavigationUrl(request.url(), { allowPrivateNetworkTargets: false });
 			if (requestError) {
 				for (const relatedPage of relatedPages) {

--- a/src/services/tab.ts
+++ b/src/services/tab.ts
@@ -442,11 +442,11 @@ function installActionTrackerScript(): void {
 	if (originalRequestAnimationFrame && originalCancelAnimationFrame) {
 		browserGlobal.requestAnimationFrame = (callback: BrowserFrameRequestCallback) => {
 			const token = state.activeToken;
+			if (token > 0) increment(token);
 			let rafId = 0;
 			const wrapped: BrowserFrameRequestCallback = (timestamp: number) => {
 				const trackedToken = state.rafTokens.get(rafId) ?? token;
 				state.rafTokens.delete(rafId);
-				if (trackedToken > 0) increment(trackedToken);
 				try {
 					return withToken(trackedToken, () => callback(timestamp));
 				} finally {
@@ -462,6 +462,7 @@ function installActionTrackerScript(): void {
 			const token = state.rafTokens.get(rafId);
 			if (token !== undefined) {
 				state.rafTokens.delete(rafId);
+				if (token > 0) decrement(token);
 			}
 			return originalCancelAnimationFrame(rafId);
 		};

--- a/src/services/tab.ts
+++ b/src/services/tab.ts
@@ -57,6 +57,7 @@ const DEFAULT_EVAL_EXTENDED_TIMEOUT = 30000;
 const MAX_RESULT_SIZE = 1048576; // 1MB
 const CONSOLE_BUFFER_SIZE = CONFIG.consoleBufferSize;
 const POST_ACTION_NAVIGATION_SETTLE_MS = 500;
+const POST_ACTION_NAVIGATION_DRAIN_TIMEOUT_MS = POST_ACTION_NAVIGATION_SETTLE_MS;
 const ACTION_TRACKER_POLL_MS = 10;
 type NavigationRoute = {
 	request: () => {
@@ -387,49 +388,45 @@ function installActionTrackerScript(): void {
 		? browserGlobal.queueMicrotask.bind(browserGlobal)
 		: null;
 
+	// Wrap tokenless callbacks too, so background work restores token 0 while a
+	// tracked action is in its bounded post-action attribution window.
 	browserGlobal.setTimeout = (handler: BrowserTimerHandler, delay?: number, ...args: unknown[]) => {
 		const token = state.activeToken;
-		if (!token) {
-			return originalSetTimeout(handler, delay, ...args);
-		}
-		increment(token);
 		let timeoutId: ReturnType<typeof setTimeout>;
 		const wrapped = (...callbackArgs: unknown[]) => {
-			const trackedToken = state.timeoutTokens.get(timeoutId) || token;
+			const trackedToken = state.timeoutTokens.get(timeoutId) ?? token;
 			state.timeoutTokens.delete(timeoutId);
 			try {
 				return withToken(trackedToken, () => runHandler(handler, callbackArgs));
 			} finally {
-				decrement(trackedToken);
+				if (trackedToken > 0) decrement(trackedToken);
 			}
 		};
 		timeoutId = originalSetTimeout(wrapped, delay, ...args);
+		if (token > 0) increment(token);
 		state.timeoutTokens.set(timeoutId, token);
 		return timeoutId;
 	};
 
 	browserGlobal.clearTimeout = (timeoutId: ReturnType<typeof setTimeout>) => {
 		const token = state.timeoutTokens.get(timeoutId);
-		if (token) {
+		if (token !== undefined) {
 			state.timeoutTokens.delete(timeoutId);
-			decrement(token);
+			if (token > 0) decrement(token);
 		}
 		return originalClearTimeout(timeoutId);
 	};
 
 	browserGlobal.setInterval = (handler: BrowserTimerHandler, delay?: number, ...args: unknown[]) => {
 		const token = state.activeToken;
-		if (!token) {
-			return originalSetInterval(handler, delay, ...args);
-		}
 		let intervalId: ReturnType<typeof setInterval>;
 		const wrapped = (...callbackArgs: unknown[]) => {
-			const trackedToken = state.intervalTokens.get(intervalId) || token;
-			increment(trackedToken);
+			const trackedToken = state.intervalTokens.get(intervalId) ?? token;
+			if (trackedToken > 0) increment(trackedToken);
 			try {
 				return withToken(trackedToken, () => runHandler(handler, callbackArgs));
 			} finally {
-				decrement(trackedToken);
+				if (trackedToken > 0) decrement(trackedToken);
 			}
 		};
 		intervalId = originalSetInterval(wrapped, delay, ...args);
@@ -445,18 +442,15 @@ function installActionTrackerScript(): void {
 	if (originalRequestAnimationFrame && originalCancelAnimationFrame) {
 		browserGlobal.requestAnimationFrame = (callback: BrowserFrameRequestCallback) => {
 			const token = state.activeToken;
-			if (!token) {
-				return originalRequestAnimationFrame(callback);
-			}
-			increment(token);
 			let rafId = 0;
 			const wrapped: BrowserFrameRequestCallback = (timestamp: number) => {
-				const trackedToken = state.rafTokens.get(rafId) || token;
+				const trackedToken = state.rafTokens.get(rafId) ?? token;
 				state.rafTokens.delete(rafId);
+				if (trackedToken > 0) increment(trackedToken);
 				try {
 					return withToken(trackedToken, () => callback(timestamp));
 				} finally {
-					decrement(trackedToken);
+					if (trackedToken > 0) decrement(trackedToken);
 				}
 			};
 			rafId = originalRequestAnimationFrame(wrapped);
@@ -466,9 +460,8 @@ function installActionTrackerScript(): void {
 
 		browserGlobal.cancelAnimationFrame = (rafId: number) => {
 			const token = state.rafTokens.get(rafId);
-			if (token) {
+			if (token !== undefined) {
 				state.rafTokens.delete(rafId);
-				decrement(token);
 			}
 			return originalCancelAnimationFrame(rafId);
 		};
@@ -477,15 +470,12 @@ function installActionTrackerScript(): void {
 	if (originalQueueMicrotask) {
 		browserGlobal.queueMicrotask = (callback: BrowserVoidFunction) => {
 			const token = state.activeToken;
-			if (!token) {
-				return originalQueueMicrotask(callback);
-			}
-			increment(token);
+			if (token > 0) increment(token);
 			return originalQueueMicrotask(() => {
 				try {
 					return withToken(token, callback);
 				} finally {
-					decrement(token);
+					if (token > 0) decrement(token);
 				}
 			});
 		};
@@ -610,8 +600,8 @@ async function getCurrentTrackedActionToken(page: Page): Promise<number | null> 
 		const token = await page.evaluate(() => {
 			return (globalThis as any).__camofoxActionTracker?.getActiveToken?.() || 0;
 		});
-		if (typeof token === 'number' && token > 0) {
-			return token;
+		if (typeof token === 'number') {
+			return token > 0 ? token : null;
 		}
 		return activeTrackedActionTokens.get(page) || null;
 	} catch {
@@ -666,6 +656,43 @@ async function yieldToPostActionNavigation(page: Page): Promise<void> {
 		return;
 	}
 	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createPostActionNavigationTimeoutError(): Error & { statusCode: number } {
+	return createNavigationBlockError('Blocked navigation guard did not settle before the action completed');
+}
+
+async function withPostActionNavigationDeadline<T>(promise: Promise<T>, deadline: number): Promise<T> {
+	const remainingMs = deadline - Date.now();
+	if (remainingMs <= 0) throw createPostActionNavigationTimeoutError();
+	try {
+		return await withTimeout(promise, remainingMs, 'post-action navigation tracking');
+	} catch {
+		throw createPostActionNavigationTimeoutError();
+	}
+}
+
+async function drainPostActionNavigation(page: Page, actionToken: number): Promise<void> {
+	const deadline = Date.now() + POST_ACTION_NAVIGATION_DRAIN_TIMEOUT_MS;
+	await withPostActionNavigationDeadline(yieldToPostActionNavigation(page), deadline);
+
+	while (true) {
+		throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
+		const pendingCount = await withPostActionNavigationDeadline(getTrackedPendingCount(page, actionToken), deadline);
+		const inFlightGuardCount = getTrackedInFlightGuardCheckCount(page, actionToken);
+		const postActionPendingWork = pendingCount > 0 || inFlightGuardCount > 0 || getInFlightGuardCheckCount(page) > 0;
+		if (!postActionPendingWork) break;
+		await withPostActionNavigationDeadline(
+			new Promise((resolve) => setTimeout(resolve, ACTION_TRACKER_POLL_MS)),
+			deadline,
+		);
+	}
+
+	throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
+	// A tokenless navigation during the settle turn is background work. It was
+	// blocked by the guard, but must not become the select action's response or
+	// leak into the next operation.
+	clearBlockedNavigationError(page);
 }
 
 export async function flushBlockedNavigationError(page: Page): Promise<void> {
@@ -748,18 +775,7 @@ export async function withBlockedNavigationTracking<T>(
 			// resolves without creating tracked timer work. Yield once while the
 			// action token is still active so the route guard can associate that
 			// request with this action before the in-flight drain below.
-			await yieldToPostActionNavigation(page);
-			let postActionPendingWork = true;
-			while (postActionPendingWork) {
-				throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
-				const pendingCount = await getTrackedPendingCount(page, actionToken);
-				const inFlightGuardCount = getTrackedInFlightGuardCheckCount(page, actionToken);
-				postActionPendingWork = pendingCount > 0 || inFlightGuardCount > 0 || getInFlightGuardCheckCount(page) > 0;
-				if (postActionPendingWork) {
-					await new Promise((resolve) => setTimeout(resolve, ACTION_TRACKER_POLL_MS));
-				}
-			}
-			throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
+			await drainPostActionNavigation(page, actionToken);
 		}
 		await finish();
 		return result;

--- a/tests/unit/tab-url-security.test.js
+++ b/tests/unit/tab-url-security.test.js
@@ -1,3 +1,5 @@
+const vm = require('node:vm');
+
 jest.mock('node:dns/promises', () => ({
   lookup: jest.fn(),
 }));
@@ -667,6 +669,109 @@ describe('validateUrl() network safety', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  test('keeps action-scheduled RAF navigation attributed until the frame runs', async () => {
+    let routeHandler;
+    let nextRafId = 1;
+    const rafCallbacks = new Map();
+    const trackerState = {
+      activeToken: 0,
+      pendingCounts: new Map(),
+    };
+    const sandbox = {
+      clearInterval,
+      clearTimeout,
+      console,
+      eval,
+      queueMicrotask,
+      requestAnimationFrame: (callback) => {
+        const rafId = nextRafId++;
+        rafCallbacks.set(rafId, callback);
+        return rafId;
+      },
+      cancelAnimationFrame: (rafId) => {
+        rafCallbacks.delete(rafId);
+      },
+      setInterval,
+      setTimeout,
+      __camofoxUpdateActiveToken: (token) => {
+        trackerState.activeToken = token;
+      },
+      __camofoxUpdatePendingCount: (token, count) => {
+        if (count > 0) trackerState.pendingCounts.set(token, count);
+        else trackerState.pendingCounts.delete(token);
+      },
+    };
+    sandbox.globalThis = sandbox;
+    const browserContext = vm.createContext(sandbox);
+    const blockedRoute = {
+      request: () => ({
+        url: () => 'http://169.254.169.254/latest/meta-data',
+        isNavigationRequest: () => true,
+        frame: () => ({ page: () => page }),
+      }),
+      continue: jest.fn().mockResolvedValue(undefined),
+      abort: jest.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+      route: jest.fn(async (_pattern, handler) => {
+        routeHandler = handler;
+      }),
+      exposeBinding: jest.fn(async (name, callback) => {
+        if (name === '__camofoxUpdateActiveToken') {
+          sandbox.__camofoxUpdateActiveToken = (token) => callback({ page }, token);
+        }
+        if (name === '__camofoxUpdatePendingCount') {
+          sandbox.__camofoxUpdatePendingCount = (token, count) => callback({ page }, token, count);
+        }
+      }),
+    };
+    const page = {
+      context: jest.fn(() => context),
+      on: jest.fn(),
+      addInitScript: jest.fn().mockResolvedValue(undefined),
+      evaluate: jest.fn(async (fn, arg) => {
+        const source = String(fn);
+        if (source.includes('installActionTrackerScript')) {
+          return vm.runInContext(`(${source})()`, browserContext);
+        }
+        if (source.includes('startAction')) {
+          return sandbox.__camofoxActionTracker.startAction(arg);
+        }
+        if (source.includes('finishAction')) {
+          return sandbox.__camofoxActionTracker.finishAction(arg);
+        }
+        if (source.includes('getPendingCount')) {
+          return sandbox.__camofoxActionTracker.getPendingCount(arg);
+        }
+        if (source.includes('getActiveToken')) {
+          return sandbox.__camofoxActionTracker.getActiveToken();
+        }
+        return undefined;
+      }),
+    };
+
+    await createTabState(page);
+    const actionPromise = withBlockedNavigationTracking(page, async () => {
+      sandbox.requestAnimationFrame(() => {
+        void routeHandler(blockedRoute);
+      });
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(rafCallbacks).toHaveProperty('size', 1);
+    expect(sandbox.__camofoxActionTracker.getPendingCount(1)).toBe(1);
+
+    const [rafId, callback] = rafCallbacks.entries().next().value;
+    rafCallbacks.delete(rafId);
+    callback(0);
+
+    await expect(actionPromise).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringContaining('Blocked private network target'),
+    });
+    expect(blockedRoute.abort).toHaveBeenCalledTimes(1);
   });
 
   test('typeTab does not miss delayed blocked navigations that require async DNS resolution', async () => {

--- a/tests/unit/tab-url-security.test.js
+++ b/tests/unit/tab-url-security.test.js
@@ -14,6 +14,7 @@ describe('validateUrl() network safety', () => {
   let scrollTab;
   let typeTab;
   let waitForPageReady;
+  let withBlockedNavigationTracking;
   let lookupMock;
   const originalHost = process.env.CAMOFOX_HOST;
   const originalApiKey = process.env.CAMOFOX_API_KEY;
@@ -24,7 +25,7 @@ describe('validateUrl() network safety', () => {
     process.env.CAMOFOX_API_KEY = 'test-key';
     ({ lookup: lookupMock } = require('node:dns/promises'));
     lookupMock.mockReset();
-    ({ validateUrl, validateNavigationUrl, navigateWithSafetyGuard, createTabState, clickTab, evaluateTab, pressTab, scrollElementTab, scrollTab, typeTab, waitForPageReady } =
+    ({ validateUrl, validateNavigationUrl, navigateWithSafetyGuard, createTabState, clickTab, evaluateTab, pressTab, scrollElementTab, scrollTab, typeTab, waitForPageReady, withBlockedNavigationTracking } =
       require('../../dist/src/services/tab'));
   });
 
@@ -405,6 +406,131 @@ describe('validateUrl() network safety', () => {
       await jest.advanceTimersByTimeAsync(700);
 
       await actionExpectation;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('keeps the action token active for navigation queued after the action promise settles', async () => {
+    let routeHandler;
+    const trackerState = {
+      activeToken: 0,
+      pendingCounts: new Map(),
+    };
+    const blockedRoute = {
+      request: () => ({
+        url: () => 'http://169.254.169.254/latest/meta-data',
+        isNavigationRequest: () => true,
+        frame: () => ({ page: () => page }),
+      }),
+      continue: jest.fn().mockResolvedValue(undefined),
+      abort: jest.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+      route: jest.fn(async (_pattern, handler) => {
+        routeHandler = handler;
+      }),
+    };
+    const page = {
+      context: jest.fn(() => context),
+      on: jest.fn(),
+      addInitScript: jest.fn().mockResolvedValue(undefined),
+      evaluate: jest.fn(async (fn, arg) => {
+        const source = String(fn);
+        if (source.includes('installActionTrackerScript')) return undefined;
+        if (source.includes('startAction')) {
+          trackerState.activeToken = arg;
+          return undefined;
+        }
+        if (source.includes('finishAction')) {
+          if (trackerState.activeToken === arg) trackerState.activeToken = 0;
+          return undefined;
+        }
+        if (source.includes('getPendingCount')) return trackerState.pendingCounts.get(arg) || 0;
+        if (source.includes('getActiveToken')) return trackerState.activeToken || 0;
+        return undefined;
+      }),
+      waitForTimeout: jest.fn((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+    };
+
+    await createTabState(page);
+    const actionPromise = withBlockedNavigationTracking(page, async () => {
+      setTimeout(() => {
+        void routeHandler(blockedRoute);
+      }, 0);
+    }, { settlePostActionNavigation: true });
+
+    await expect(actionPromise).rejects.toMatchObject({
+      statusCode: 400,
+      message: expect.stringContaining('Blocked private network target'),
+    });
+    expect(blockedRoute.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test('drains an asynchronous guard check queued after the action promise settles', async () => {
+    jest.useFakeTimers();
+    try {
+      lookupMock.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve([{ address: '127.0.0.1', family: 4 }]), 50)),
+      );
+
+      let routeHandler;
+      const trackerState = {
+        activeToken: 0,
+        pendingCounts: new Map(),
+      };
+      const blockedRoute = {
+        request: () => ({
+          url: () => 'http://public-looking.example.test/latest/meta-data',
+          isNavigationRequest: () => true,
+          frame: () => ({ page: () => page }),
+        }),
+        continue: jest.fn().mockResolvedValue(undefined),
+        abort: jest.fn().mockResolvedValue(undefined),
+      };
+      const context = {
+        route: jest.fn(async (_pattern, handler) => {
+          routeHandler = handler;
+        }),
+      };
+      const page = {
+        context: jest.fn(() => context),
+        on: jest.fn(),
+        addInitScript: jest.fn().mockResolvedValue(undefined),
+        evaluate: jest.fn(async (fn, arg) => {
+          const source = String(fn);
+          if (source.includes('installActionTrackerScript')) return undefined;
+          if (source.includes('startAction')) {
+            trackerState.activeToken = arg;
+            return undefined;
+          }
+          if (source.includes('finishAction')) {
+            if (trackerState.activeToken === arg) trackerState.activeToken = 0;
+            return undefined;
+          }
+          if (source.includes('getPendingCount')) return trackerState.pendingCounts.get(arg) || 0;
+          if (source.includes('getActiveToken')) {
+            return new Promise((resolve) => setTimeout(() => resolve(trackerState.activeToken || 0), 5));
+          }
+          return undefined;
+        }),
+        waitForTimeout: jest.fn((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+      };
+
+      await createTabState(page);
+      const actionPromise = withBlockedNavigationTracking(page, async () => {
+        setTimeout(() => {
+          void routeHandler(blockedRoute);
+        }, 0);
+      }, { settlePostActionNavigation: true });
+      const actionExpectation = expect(actionPromise).rejects.toMatchObject({
+        statusCode: 400,
+        message: expect.stringContaining('Blocked private network target'),
+      });
+
+      await jest.advanceTimersByTimeAsync(100);
+      await actionExpectation;
+      expect(blockedRoute.abort).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }

--- a/tests/unit/tab-url-security.test.js
+++ b/tests/unit/tab-url-security.test.js
@@ -15,6 +15,7 @@ describe('validateUrl() network safety', () => {
   let typeTab;
   let waitForPageReady;
   let withBlockedNavigationTracking;
+  let withTabLock;
   let lookupMock;
   const originalHost = process.env.CAMOFOX_HOST;
   const originalApiKey = process.env.CAMOFOX_API_KEY;
@@ -25,7 +26,7 @@ describe('validateUrl() network safety', () => {
     process.env.CAMOFOX_API_KEY = 'test-key';
     ({ lookup: lookupMock } = require('node:dns/promises'));
     lookupMock.mockReset();
-    ({ validateUrl, validateNavigationUrl, navigateWithSafetyGuard, createTabState, clickTab, evaluateTab, pressTab, scrollElementTab, scrollTab, typeTab, waitForPageReady, withBlockedNavigationTracking } =
+    ({ validateUrl, validateNavigationUrl, navigateWithSafetyGuard, createTabState, clickTab, evaluateTab, pressTab, scrollElementTab, scrollTab, typeTab, waitForPageReady, withBlockedNavigationTracking, withTabLock } =
       require('../../dist/src/services/tab'));
   });
 
@@ -531,6 +532,138 @@ describe('validateUrl() network safety', () => {
       await jest.advanceTimersByTimeAsync(100);
       await actionExpectation;
       expect(blockedRoute.abort).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('does not blame a select action for tokenless background navigation during settle', async () => {
+    let routeHandler;
+    const trackerState = {
+      activeToken: 0,
+      pendingCounts: new Map(),
+    };
+    const blockedRoute = {
+      request: () => ({
+        url: () => 'http://169.254.169.254/latest/meta-data',
+        isNavigationRequest: () => true,
+        frame: () => ({ page: () => page }),
+      }),
+      continue: jest.fn().mockResolvedValue(undefined),
+      abort: jest.fn().mockResolvedValue(undefined),
+    };
+    const context = {
+      route: jest.fn(async (_pattern, handler) => {
+        routeHandler = handler;
+      }),
+    };
+    const page = {
+      context: jest.fn(() => context),
+      on: jest.fn(),
+      addInitScript: jest.fn().mockResolvedValue(undefined),
+      evaluate: jest.fn(async (fn, arg) => {
+        const source = String(fn);
+        if (source.includes('installActionTrackerScript')) return undefined;
+        if (source.includes('startAction')) {
+          trackerState.activeToken = arg;
+          return undefined;
+        }
+        if (source.includes('finishAction')) {
+          if (trackerState.activeToken === arg) trackerState.activeToken = 0;
+          return undefined;
+        }
+        if (source.includes('getPendingCount')) return trackerState.pendingCounts.get(arg) || 0;
+        if (source.includes('getActiveToken')) return trackerState.activeToken || 0;
+        return undefined;
+      }),
+      waitForTimeout: jest.fn((ms) => new Promise((resolve) => setTimeout(resolve, ms === 0 ? 30 : ms))),
+    };
+
+    await createTabState(page);
+    const actionPromise = withBlockedNavigationTracking(page, async () => {
+      setTimeout(() => {
+        trackerState.activeToken = 0;
+        void routeHandler(blockedRoute);
+      }, 20);
+    }, { settlePostActionNavigation: true });
+
+    await expect(actionPromise).resolves.toBeUndefined();
+    expect(blockedRoute.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test('bounds a stuck post-action guard and releases the tab lock', async () => {
+    jest.useFakeTimers();
+    let resolveLookup;
+    try {
+      lookupMock.mockImplementation(
+        () => new Promise((resolve) => {
+          resolveLookup = resolve;
+        }),
+      );
+
+      let routeHandler;
+      const trackerState = {
+        activeToken: 0,
+        pendingCounts: new Map(),
+      };
+      const blockedRoute = {
+        request: () => ({
+          url: () => 'http://public-looking.example.test/latest/meta-data',
+          isNavigationRequest: () => true,
+          frame: () => ({ page: () => page }),
+        }),
+        continue: jest.fn().mockResolvedValue(undefined),
+        abort: jest.fn().mockResolvedValue(undefined),
+      };
+      const context = {
+        route: jest.fn(async (_pattern, handler) => {
+          routeHandler = handler;
+        }),
+      };
+      const page = {
+        context: jest.fn(() => context),
+        on: jest.fn(),
+        addInitScript: jest.fn().mockResolvedValue(undefined),
+        evaluate: jest.fn(async (fn, arg) => {
+          const source = String(fn);
+          if (source.includes('installActionTrackerScript')) return undefined;
+          if (source.includes('startAction')) {
+            trackerState.activeToken = arg;
+            return undefined;
+          }
+          if (source.includes('finishAction')) {
+            if (trackerState.activeToken === arg) trackerState.activeToken = 0;
+            return undefined;
+          }
+          if (source.includes('getPendingCount')) return trackerState.pendingCounts.get(arg) || 0;
+          if (source.includes('getActiveToken')) return trackerState.activeToken || 0;
+          return undefined;
+        }),
+        waitForTimeout: jest.fn((ms) => new Promise((resolve) => setTimeout(resolve, ms === 0 ? 30 : ms))),
+      };
+
+      await createTabState(page);
+      const firstAction = withTabLock('stuck-tab', () => withBlockedNavigationTracking(page, async () => {
+        setTimeout(() => {
+          void routeHandler(blockedRoute);
+        }, 20);
+      }, { settlePostActionNavigation: true }));
+      const firstExpectation = expect(firstAction).rejects.toMatchObject({
+        statusCode: 400,
+        message: expect.stringContaining('did not settle'),
+      });
+
+      await jest.advanceTimersByTimeAsync(700);
+      await firstExpectation;
+
+      let secondRan = false;
+      await withTabLock('stuck-tab', async () => {
+        secondRan = true;
+      });
+      expect(secondRan).toBe(true);
+
+      resolveLookup([{ address: '8.8.8.8', family: 4 }]);
+      await jest.runOnlyPendingTimersAsync();
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## Summary

The CI failure on PR #25 exposed a race in the shared blocked-navigation tracker, not in the userId validation change.

A DOM action can resolve before its synchronous event handler queues a navigation. The route guard then starts after the action token is finished, so the blocked private-network request is not attributed to the action and the endpoint can return 200 instead of 400.

This patch:
- adds an opt-in post-action settle/drain for the OpenClaw select action;
- bounds the drain and releases the tab lock on timeout;
- preserves token-0 attribution for background timers, intervals, RAF, and microtasks;
- counts positive-token RAF work when scheduled and decrements it on callback or cancellation;
- keeps asynchronous guard checks associated with the action while they are in flight;
- adds regression coverage using the actual browser tracker script.

## Verification

- Local unit tracker/security suite: 27/27 passed.
- Local security-hardening E2E: 11/11 passed.
- npm run build, lint/typecheck, and npm run verify:package: passed.
- GitHub CI run 31167638346: Node 20 and Node 22 both passed lint, build, and the full test job.
- Independent read-only review of head 77699fd: no material code findings.
- The original run 31100675312 remains historical evidence for PR #25; PR #29 is the separate fix.

Related: #25
