### PR TITLE
Release: finalize v2.4.7 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [2.4.7] - 2026-08-11
+## [2.4.7] - 2026-08-13
 
 ### Added
 - Added official Windows x64 headless support and a reproducible portable ZIP build that bundles Node.js, the application runtime, the pinned Camoufox Windows x64 engine, portable runtime state under `data\home`, and third-party licensing notices.
@@ -19,11 +19,14 @@
 ### Fixed
 - Windows now rejects headed and virtual/Xvfb/VNC display modes before Linux-only display processes can be attempted, while preserving existing Linux/macOS display behavior.
 - New Windows persistent profile directories now use deterministic hashed internal keys, preventing distinct case-sensitive user/session identities from aliasing on case-insensitive Windows filesystems while leaving Linux/macOS profile naming unchanged. Existing Windows directories from the previous layout remain readable in place when the exact legacy name is unambiguous; if both old and hashed directories exist, or Windows resolves a different case/trailing-dot/space-equivalent legacy name, profile launch fails closed and reports the paths to back up/reconcile instead of silently choosing or migrating state.
+- Navigation health recovery now tracks failures per session, counts only actual navigation failures, preserves unrelated sibling sessions, and applies the same recovery behavior to core and OpenClaw tab-opening routes.
+- Concurrent recovery teardown and same-key context relaunch now use opaque session generations and exact context identity guards, preserving a healthy replacement session even when timestamps collide or lifecycle callbacks arrive late.
 
 ### Tests
 - Added focused Windows platform and VNC side-effect regression tests plus a launcher test that removes Node from `PATH` and verifies the current runtime is reused.
 - Jest now isolates profiles, cookies, downloads, and traces under a disposable temp root and removes it after the run, preventing test/build verification from accumulating persistent state under the operator's `~/.camofox` directory.
 - Long-running session lifecycle coverage now reclaims its disposable profiles/downloads/cookies/traces after each fully closed case, preventing in-run profile buildup from exhausting Windows CI while retaining every lifecycle assertion.
+- Added production-boundary lifecycle regressions for recovery/relaunch overlap and equal-timestamp collisions, plus real Express coverage for OpenClaw `POST /tabs/open` recovery thresholds, success resets, and non-navigation isolation.
 
 ## [2.4.6] - 2026-06-17
 


### PR DESCRIPTION
## Release gate

Finalizes the existing `2.4.7` changelog entry on top of merged PR #27.

- Records session-scoped navigation recovery and OpenClaw parity.
- Records immutable generation fencing for recovery/relaunch overlap.
- Sets the release date to 2026-08-13.
- Does not change production code, dependencies, package identity, or release workflow.

## Verification

- `npm run build` — pass
- `npm run lint` — pass
- `npm run verify:package` — pass, clean-install tarball and plugin identity `2.4.7`
- Node 20 full Jest — 659/660 executed tests pass; the sole broad-run failure was a 5-second Playwright click timeout in unchanged `tests/e2e/screenshot.test.js`, then the exact suite passed 8/8 immediately in isolation
- PR #27 exact-head CI — all five checks pass
- Post-merge main CI is required before this release PR is merged

Release publication remains gated on this PR CI, exact merged-main CI, tag contract, Docker publication, and GitHub portable ZIP readback.