### PR TITLE
Bound the post-action drain loop so busy pages cannot deadlock a tab

### DIFF
--- a/src/services/tab.ts
+++ b/src/services/tab.ts
@@ -59,6 +59,17 @@ const CONSOLE_BUFFER_SIZE = CONFIG.consoleBufferSize;
 const POST_ACTION_NAVIGATION_SETTLE_MS = 500;
 const POST_ACTION_NAVIGATION_DRAIN_TIMEOUT_MS = POST_ACTION_NAVIGATION_SETTLE_MS;
 const ACTION_TRACKER_POLL_MS = 10;
+// Upper bound on the post-action drain loop below. The loop waits for tracked
+// async work (setTimeout/setInterval/rAF) to reach zero, which never happens on
+// pages with perpetual background activity -- a heartbeat interval, an analytics
+// beacon, or an animating carousel driving requestAnimationFrame every frame.
+// Without a deadline the loop spins forever while holding the tab lock, so the
+// caller's timeout rejects the request but the lock is never released and every
+// later call on that tab queues behind it. Draining is a best-effort settle, not
+// a correctness requirement: blocked-navigation errors are still checked before
+// and after, so timing out here degrades to "proceed without a full settle"
+// rather than losing the guard.
+const ACTION_TRACKER_DRAIN_TIMEOUT_MS = 3000;
 type NavigationRoute = {
 	request: () => {
 		url: () => string;
@@ -742,10 +753,17 @@ export async function withBlockedNavigationTracking<T>(
 		}
 
 		let sawPendingWork = false;
+		const drainDeadline = Date.now() + ACTION_TRACKER_DRAIN_TIMEOUT_MS;
 		while (true) {
 			throwTrackedBlockedNavigationErrorIfPresent(page, actionToken);
 			if (sawPendingWork) {
 				throwBlockedNavigationErrorIfPresent(page);
+			}
+			if (Date.now() >= drainDeadline) {
+				log('warn', 'action drain timed out, proceeding without full settle', {
+					timeoutMs: ACTION_TRACKER_DRAIN_TIMEOUT_MS,
+				});
+				break;
 			}
 			const pendingCount = await getTrackedPendingCount(page, actionToken);
 			const inFlightGuardCount = getTrackedInFlightGuardCheckCount(page, actionToken);

--- a/tests/unit/tab-url-security.test.js
+++ b/tests/unit/tab-url-security.test.js
@@ -734,6 +734,69 @@ describe('validateUrl() network safety', () => {
     }
   });
 
+  test('bounds the drain on a page whose tracked work never reaches zero', async () => {
+    // Pages with perpetual background activity -- a heartbeat interval, an
+    // analytics beacon, an animating carousel driving rAF every frame -- never
+    // report a pending count of zero. The drain loop must give up on its own
+    // deadline instead of spinning forever while holding the tab lock.
+    jest.useFakeTimers();
+    try {
+      const trackerState = {
+        activeToken: 0,
+        // Never drains: mimics a page with a permanently live interval/rAF.
+        pendingCounts: new Map(),
+      };
+      const context = { route: jest.fn(async () => {}) };
+      const page = {
+        context: jest.fn(() => context),
+        on: jest.fn(),
+        addInitScript: jest.fn().mockResolvedValue(undefined),
+        evaluate: jest.fn(async (fn, arg) => {
+          const source = String(fn);
+          if (source.includes('installActionTrackerScript')) return undefined;
+          if (source.includes('startAction')) {
+            trackerState.activeToken = arg;
+            return undefined;
+          }
+          if (source.includes('finishAction')) {
+            if (trackerState.activeToken === arg) trackerState.activeToken = 0;
+            return undefined;
+          }
+          // Always busy, no matter how long the loop waits.
+          if (source.includes('getPendingCount')) return 1;
+          if (source.includes('getActiveToken')) return trackerState.activeToken || 0;
+          return undefined;
+        }),
+        waitForTimeout: jest.fn((ms) => new Promise((resolve) => setTimeout(resolve, ms === 0 ? 30 : ms))),
+      };
+
+      await createTabState(page);
+
+      let settled = false;
+      const action = withTabLock('busy-tab', () => withBlockedNavigationTracking(page, async () => 'result'))
+        .then((value) => {
+          settled = true;
+          return value;
+        });
+
+      // Well past the drain deadline: the loop must have given up by now.
+      await jest.advanceTimersByTimeAsync(10000);
+
+      await expect(action).resolves.toBe('result');
+      expect(settled).toBe(true);
+
+      // The lock must be free for the next caller, which is what the unbounded
+      // loop broke: the request timed out but the loop kept the lock forever.
+      let secondRan = false;
+      await withTabLock('busy-tab', async () => {
+        secondRan = true;
+      });
+      expect(secondRan).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('keeps action-scheduled RAF navigation attributed until the frame runs', async () => {
     let routeHandler;
     let nextRafId = 1;


### PR DESCRIPTION
## The bug

`withBlockedNavigationTracking` drains tracked async work after an action by polling until the pending count reaches zero (`src/services/tab.ts`). The loop had no deadline and no iteration cap, so it assumed every page eventually goes quiet.

Real sites often never do. A chat-widget heartbeat, an analytics beacon, or an animating carousel driving `requestAnimationFrame` every frame keeps the tracked pending count permanently above zero, and the loop spins forever.

## Why it is worse than a slow call

The loop holds the tab lock:

1. The loop spins, so the caller's timeout rejects the HTTP request.
2. The timeout does not cancel the loop, which keeps running and keeps the lock.
3. Every later call on that tab queues behind a lock that is never released.

The tab is then wedged for good.

## How it showed up

Observed on several car-dealer sites. The first `snapshot` returned `snapshot timed out after 30000ms`, and every subsequent `snapshot`, `click`, and `evaluate` on that tab hung until the session was torn down. Plain screenshots kept working (they do not take the tab lock), which made it look like a page-load problem rather than a lock problem.

Measured on one such page, with the SSRF guard fully enabled:

| | before | after |
|---|---|---|
| first snapshot | 30s timeout, fails | 6.7s, succeeds |
| follow-up evaluate | hangs | 27ms |
| follow-up snapshot | hangs | 0.35s |

No regression on quiet pages: `example.com` snapshots in 0.28s and never reaches the deadline.

## The fix

Give the drain a 3s deadline and proceed without a full settle when it expires. Draining is a best-effort settle rather than a correctness requirement: blocked-navigation errors are still checked before and after the loop, so expiry degrades to a less-settled page, not a lost guard. This deliberately avoids the `CAMOFOX_ALLOW_PRIVATE_NETWORK=true` escape hatch, which would disable the SSRF protection entirely.

## Test

The added regression test hangs to the 60s Jest timeout without this change and passes in 7ms with it.

Full unit suite: 486 passing. The 10 failures in `tests/unit/security.test.js` and the cookie suite are pre-existing on an unmodified tree (they require a live browser/server) and are unrelated to this change.
